### PR TITLE
fix: use API-provided QR image for QR code login

### DIFF
--- a/custom_components/ha_cloud_music/browse_media.py
+++ b/custom_components/ha_cloud_music/browse_media.py
@@ -268,9 +268,9 @@ async def async_browse_media(media_player, media_content_type, media_content_id)
                 res = await cloud_music.netease_cloud_music('/login/qr/key')
                 if res['code'] == 200:
                     codekey = res['data']['unikey']
-                    res = await cloud_music.netease_cloud_music(f'/login/qr/create?key={codekey}')
+                    res = await cloud_music.netease_cloud_music(f'/login/qr/create?key={codekey}&qrimg=true')
                     qr['key'] = codekey
-                    qr['url'] = res['data']['qrurl']
+                    qr['url'] = res['data']['qrimg'] if res['data']['qrimg'] != '' else f'https://cdn.dotmaui.com/qrc/?t={res["data"]["qrurl"]}'
                     qr['time'] = now
 
             return BrowseMedia(
@@ -288,7 +288,7 @@ async def async_browse_media(media_player, media_content_type, media_content_id)
                         media_content_id=CloudMusicRouter.my_login + '?action=login&id=' + qr['key'],
                         can_play=False,
                         can_expand=True,
-                        thumbnail=f'https://cdn.dotmaui.com/qrc/?t={qr["url"]}'
+                        thumbnail=qr['url']
                     )
                 ],
             )


### PR DESCRIPTION
修复扫码登录二维码图片显示异常的问题。

### 变更

- 请求 `/login/qr/create` 时增加 `qrimg=true`
- 优先使用接口返回的 `qrimg` 作为二维码缩略图
- 当 `qrimg` 为空时，保留原来的 `qrurl` 第三方二维码渲染方式作为 fallback

### 原因

当前实现依赖 `cdn.dotmaui.com` 根据 `qrurl` 渲染二维码图片。  
近期实际使用中，该外部二维码图片已无法正常显示，导致 Home Assistant 媒体浏览器里的扫码登录二维码无法显示。

这个问题也可以通过替换或修复第三方二维码渲染地址解决，但云音乐API接口本身在传入 `qrimg=true` 时已经可以返回二维码图片数据。相比继续依赖额外的二维码渲染服务，直接使用接口返回的 `qrimg` 更简单，也能减少外部依赖，同时不改变原有登录流程。

### 验证

- 已测试扫码登录二维码可以正常显示
- 已运行：

```bash
python -m compileall custom_components/ha_cloud_music